### PR TITLE
Add cs:name nodes only when necessary

### DIFF
--- a/lib/csl_json.js
+++ b/lib/csl_json.js
@@ -332,30 +332,30 @@ CSL_JSON.prototype.insertPublisherAndPlace = function(myxml) {
 };
 */
 
-CSL_JSON.prototype.addMissingNameNodes = function(myjson,parentname) {
-    //print("addMissingNameNodes()");
+CSL_JSON.prototype.addMissingNameNodes = function(myjson,parents) {
+    if (!parents) parents = [];
     if (myjson.name === "names") {
         // Trawl through children to decide whether a name node is needed here
-        var addNameNode = true;
-        if ("substitute" !== parentname) {
+        if (parents.indexOf("substitute") === -1) {
+            var addName = true;
             for (var i=0,ilen=myjson.children.length;i<ilen;i++) {
-                var child = myjson.children[i];
-                if (child.name === "substitute") break;
-                if (child.name === "name") {
-                    addNameNode = false;
+                if (myjson.children[i].name === "name") {
+                    addName = false;
                     break;
                 }
             }
-        }
-        if (addNameNode) {
-            myjson.children = [{name:"name",attrs:{},children:[]}].concat(myjson.children);
+            if (addName) {
+                myjson.children = [{name:"name",attrs:{},children:[]}].concat(myjson.children);
+            }
         }
     }
+    parents.push(myjson.name);
     for (var i=0,ilen=myjson.children.length;i<ilen;i+=1) {
         if ("object" === typeof myjson.children[i]) {
-            this.addMissingNameNodes(myjson.children[i],myjson.name);
+            this.addMissingNameNodes(myjson.children[i],parents);
         }
     }
+    parents.pop();
 }
 
 CSL_JSON.prototype.addInstitutionNodes = function(myjson) {


### PR DESCRIPTION
Bare `cs:names` nodes became legal in CSL after the `citeproc-js` name formatting code was complete. To process them without reworking existing code, I added an `addMissingNameNodes()` function to the input parsers, and called it from processor code.

The function definition in `xmljson.js` had a bug that made it over-aggressive. As a result, in some styles an extraneous minimal `cs:name` node was appended after an existing node, causing formatting attributes to be lost, triggering the bug discussed in #26.

This PR should clear the bug.